### PR TITLE
Ctrl+d

### DIFF
--- a/menace-cli/src/ui/update.go
+++ b/menace-cli/src/ui/update.go
@@ -57,7 +57,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			changed = true
 
 		//Case for delete key press
-		case tea.KeyDelete.String():
+		case tea.KeyDelete.String(), tea.KeyCtrlD.String():
 			m.HandleDelete()
 			changed = true
 


### PR DESCRIPTION
Made that on you can use ctrl + d, to delete characters on right side of cursor
use case: mac os 